### PR TITLE
fix: resolve Vercel 404 error with "rewrites" feature

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
Fixed the Vercel 404 error caused by child URL path issues by configuring Vercel's "rewrites" feature to handle routing correctly and ensure proper navigation within the application.